### PR TITLE
Update deprecated sqliteTable calls in /db/schema

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -1,22 +1,15 @@
 import { env } from "@/env";
-import { createClient } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 
 import * as schema from "./schema";
 
-const sql = createClient({
-	url: env.DATABASE_URL,
-	authToken: env.DATABASE_TOKEN,
+export const db = drizzle({
+	connection: {
+		url: env.DATABASE_URL,
+		authToken: env.DATABASE_TOKEN,
+	},
+	schema,
+	casing: "snake_case",
 });
 
-export const db = drizzle(sql, { schema, casing: "snake_case" });
-
-// export const db = await drizzle("turso", {
-// 	connection: {
-// 		url: env.DATABASE_URL,
-// 		authToken: env.DATABASE_TOKEN,
-// 	},
-// 	schema,
-// 	casing: "snake_case",
-// });
 export type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/db/schema/aircraft.ts
+++ b/db/schema/aircraft.ts
@@ -1,7 +1,7 @@
 import { users } from "@/db/schema/auth";
 import { logs } from "@/db/schema/logs";
-import { relations, text } from "drizzle-orm";
-import { sqliteTable } from "drizzle-orm/sqlite-core";
+import { relations } from "drizzle-orm";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
 export const aircraft = sqliteTable("aircraft", {

--- a/db/schema/aircraft.ts
+++ b/db/schema/aircraft.ts
@@ -1,18 +1,17 @@
 import { users } from "@/db/schema/auth";
 import { logs } from "@/db/schema/logs";
-import { relations } from "drizzle-orm";
+import { relations, text } from "drizzle-orm";
 import { sqliteTable } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
-export const aircraft = sqliteTable("aircraft", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	userId: t
-		.text()
+export const aircraft = sqliteTable("aircraft", {
+	id: text().primaryKey().$defaultFn(v7),
+	userId: text()
 		.notNull()
 		.references(() => users.id),
-	model: t.text().notNull(),
-	registration: t.text().notNull(),
-}));
+	model: text().notNull(),
+	registration: text().notNull(),
+});
 
 export const aircraftRelations = relations(aircraft, ({ one, many }) => ({
 	user: one(users, {

--- a/db/schema/auth.ts
+++ b/db/schema/auth.ts
@@ -4,7 +4,12 @@ import { pilots } from "@/db/schema/pilots";
 import { places } from "@/db/schema/places";
 import { simulators } from "@/db/schema/simulators";
 import { relations } from "drizzle-orm";
-import { primaryKey, sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import {
+	primaryKey,
+	sqliteTable,
+	text,
+	integer,
+} from "drizzle-orm/sqlite-core";
 import type { AdapterAccountType } from "next-auth/adapters";
 import { v7 } from "uuid";
 
@@ -39,11 +44,11 @@ export const accounts = sqliteTable(
 		// biome-ignore lint/style/useNamingConvention: <explanation>
 		session_state: text("session_state"),
 	},
-	(account) => ({
-		compoundKey: primaryKey({
+	(account) => [
+		primaryKey({
 			columns: [account.provider, account.providerAccountId],
 		}),
-	}),
+	],
 );
 
 export const sessions = sqliteTable("sessions", {

--- a/db/schema/auth.ts
+++ b/db/schema/auth.ts
@@ -5,10 +5,10 @@ import { places } from "@/db/schema/places";
 import { simulators } from "@/db/schema/simulators";
 import { relations } from "drizzle-orm";
 import {
+	integer,
 	primaryKey,
 	sqliteTable,
 	text,
-	integer,
 } from "drizzle-orm/sqlite-core";
 import type { AdapterAccountType } from "next-auth/adapters";
 import { v7 } from "uuid";

--- a/db/schema/auth.ts
+++ b/db/schema/auth.ts
@@ -4,42 +4,41 @@ import { pilots } from "@/db/schema/pilots";
 import { places } from "@/db/schema/places";
 import { simulators } from "@/db/schema/simulators";
 import { relations } from "drizzle-orm";
-import { primaryKey, sqliteTable } from "drizzle-orm/sqlite-core";
+import { primaryKey, sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 import type { AdapterAccountType } from "next-auth/adapters";
 import { v7 } from "uuid";
 
-export const users = sqliteTable("users", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	name: t.text(),
-	email: t.text().notNull(),
-	emailVerified: t.integer("emailVerified", { mode: "timestamp_ms" }),
-	image: t.text(),
-}));
+export const users = sqliteTable("users", {
+	id: text().primaryKey().$defaultFn(v7),
+	name: text(),
+	email: text().notNull(),
+	emailVerified: integer("emailVerified", { mode: "timestamp_ms" }),
+	image: text(),
+});
 
 export const accounts = sqliteTable(
 	"accounts",
-	(t) => ({
-		userId: t
-			.text("userId")
+	{
+		userId: text("userId")
 			.notNull()
 			.references(() => users.id, { onDelete: "cascade" }),
-		type: t.text().$type<AdapterAccountType>().notNull(),
-		provider: t.text().notNull(),
-		providerAccountId: t.text("providerAccountId").notNull(),
+		type: text().$type<AdapterAccountType>().notNull(),
+		provider: text().notNull(),
+		providerAccountId: text("providerAccountId").notNull(),
 		// biome-ignore lint/style/useNamingConvention: <explanation>
-		refresh_token: t.text("refresh_token"),
+		refresh_token: text("refresh_token"),
 		// biome-ignore lint/style/useNamingConvention: <explanation>
-		access_token: t.text("access_token"),
+		access_token: text("access_token"),
 		// biome-ignore lint/style/useNamingConvention: <explanation>
-		expires_at: t.integer("expires_at"),
+		expires_at: integer("expires_at"),
 		// biome-ignore lint/style/useNamingConvention: <explanation>
-		token_type: t.text("token_type"),
-		scope: t.text("scope"),
+		token_type: text("token_type"),
+		scope: text("scope"),
 		// biome-ignore lint/style/useNamingConvention: <explanation>
-		id_token: t.text("id_token"),
+		id_token: text("id_token"),
 		// biome-ignore lint/style/useNamingConvention: <explanation>
-		session_state: t.text("session_state"),
-	}),
+		session_state: text("session_state"),
+	},
 	(account) => ({
 		compoundKey: primaryKey({
 			columns: [account.provider, account.providerAccountId],
@@ -47,18 +46,17 @@ export const accounts = sqliteTable(
 	}),
 );
 
-export const sessions = sqliteTable("sessions", (t) => ({
-	sessionToken: t.text("sessionToken").primaryKey(),
-	userId: t
-		.text("userId")
+export const sessions = sqliteTable("sessions", {
+	sessionToken: text("sessionToken").primaryKey(),
+	userId: text("userId")
 		.notNull()
 		.references(() => users.id, { onDelete: "cascade" }),
-	expires: t.integer({ mode: "timestamp_ms" }).notNull(),
-}));
+	expires: integer({ mode: "timestamp_ms" }).notNull(),
+});
 
-export const allowedUsers = sqliteTable("allowed_users", (t) => ({
-	email: t.text().primaryKey(),
-}));
+export const allowedUsers = sqliteTable("allowed_users", {
+	email: text().primaryKey(),
+});
 
 export const usersRelations = relations(users, ({ many }) => ({
 	aircraft: many(aircraft),

--- a/db/schema/logs.ts
+++ b/db/schema/logs.ts
@@ -4,47 +4,40 @@ import { pilots } from "@/db/schema/pilots";
 import { places } from "@/db/schema/places";
 import { times } from "@/db/schema/times";
 import { relations } from "drizzle-orm";
-import { sqliteTable } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
-export const logs = sqliteTable("logs", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	userId: t
-		.text()
+export const logs = sqliteTable("logs", {
+	id: text().primaryKey().$defaultFn(v7),
+	userId: text()
 		.notNull()
 		.references(() => users.id),
-	departureAt: t.integer({ mode: "timestamp_ms" }).notNull(),
-	arrivalAt: t.integer({ mode: "timestamp_ms" }).notNull(),
-	departurePlaceId: t
-		.text()
+	departureAt: integer({ mode: "timestamp_ms" }).notNull(),
+	arrivalAt: integer({ mode: "timestamp_ms" }).notNull(),
+	departurePlaceId: text()
 		.notNull()
 		.references(() => places.id),
-	arrivalPlaceId: t
-		.text()
+	arrivalPlaceId: text()
 		.notNull()
 		.references(() => places.id),
-	aircraftId: t
-		.text()
+	aircraftId: text()
 		.notNull()
 		.references(() => aircraft.id),
-	pilotInCommandId: t
-		.text()
+	pilotInCommandId: text()
 		.notNull()
 		.references(() => pilots.id),
-	takeoffsDay: t.integer(),
-	takeoffsNight: t.integer(),
-	landingsDay: t.integer(),
-	landingsNight: t.integer(),
-	singularTimesId: t
-		.text()
+	takeoffsDay: integer(),
+	takeoffsNight: integer(),
+	landingsDay: integer(),
+	landingsNight: integer(),
+	singularTimesId: text()
 		.notNull()
 		.references(() => times.id),
-	cumulatedTimesId: t
-		.text()
+	cumulatedTimesId: text()
 		.notNull()
 		.references(() => times.id),
-	remarks: t.text(),
-}));
+	remarks: text(),
+});
 
 export const logsRelations = relations(logs, ({ one }) => ({
 	user: one(users, {

--- a/db/schema/logs.ts
+++ b/db/schema/logs.ts
@@ -4,7 +4,7 @@ import { pilots } from "@/db/schema/pilots";
 import { places } from "@/db/schema/places";
 import { times } from "@/db/schema/times";
 import { relations } from "drizzle-orm";
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
 export const logs = sqliteTable("logs", {

--- a/db/schema/pilots.ts
+++ b/db/schema/pilots.ts
@@ -1,7 +1,7 @@
 import { users } from "@/db/schema/auth";
 import { logs } from "@/db/schema/logs";
-import { relations, text } from "drizzle-orm";
-import { sqliteTable } from "drizzle-orm/sqlite-core";
+import { relations } from "drizzle-orm";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
 export const pilots = sqliteTable("pilots", {

--- a/db/schema/pilots.ts
+++ b/db/schema/pilots.ts
@@ -1,17 +1,16 @@
 import { users } from "@/db/schema/auth";
 import { logs } from "@/db/schema/logs";
-import { relations } from "drizzle-orm";
+import { relations, text } from "drizzle-orm";
 import { sqliteTable } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
-export const pilots = sqliteTable("pilots", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	userId: t
-		.text()
+export const pilots = sqliteTable("pilots", {
+	id: text().primaryKey().$defaultFn(v7),
+	userId: text()
 		.notNull()
 		.references(() => users.id),
-	name: t.text().notNull(),
-}));
+	name: text().notNull(),
+});
 
 export const pilotsRelations = relations(pilots, ({ one, many }) => ({
 	user: one(users, {

--- a/db/schema/places.ts
+++ b/db/schema/places.ts
@@ -1,7 +1,7 @@
 import { users } from "@/db/schema/auth";
 import { logs } from "@/db/schema/logs";
-import { relations, text } from "drizzle-orm";
-import { sqliteTable } from "drizzle-orm/sqlite-core";
+import { relations } from "drizzle-orm";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
 export const places = sqliteTable("places", {

--- a/db/schema/places.ts
+++ b/db/schema/places.ts
@@ -1,17 +1,16 @@
 import { users } from "@/db/schema/auth";
 import { logs } from "@/db/schema/logs";
-import { relations } from "drizzle-orm";
+import { relations, text } from "drizzle-orm";
 import { sqliteTable } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
-export const places = sqliteTable("places", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	userId: t
-		.text()
+export const places = sqliteTable("places", {
+	id: text().primaryKey().$defaultFn(v7),
+	userId: text()
 		.notNull()
 		.references(() => users.id),
-	name: t.text().notNull(),
-}));
+	name: text().notNull(),
+});
 
 export const placesRelations = relations(places, ({ one, many }) => ({
 	user: one(users, {

--- a/db/schema/simulators.ts
+++ b/db/schema/simulators.ts
@@ -1,15 +1,14 @@
 import { users } from "@/db/schema/auth";
 import { relations } from "drizzle-orm";
-import { sqliteTable } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
-export const simulators = sqliteTable("simulators", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	userId: t
-		.text()
+export const simulators = sqliteTable("simulators", {
+	id: text().primaryKey().$defaultFn(v7),
+	userId: text()
 		.notNull()
 		.references(() => users.id),
-}));
+});
 
 export const simulatorsRelations = relations(simulators, ({ one }) => ({
 	user: one(users, {

--- a/db/schema/times.ts
+++ b/db/schema/times.ts
@@ -1,19 +1,19 @@
-import { sqliteTable } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
-export const times = sqliteTable("times", (t) => ({
-	id: t.text().primaryKey().$defaultFn(v7),
-	totalFlight: t.integer().notNull().default(0),
-	singlePilotSingleEngine: t.integer().notNull().default(0),
-	singlePilotMultiEngine: t.integer().notNull().default(0),
-	multiPilot: t.integer().notNull().default(0),
-	operationalConditionNight: t.integer().notNull().default(0),
-	operationalConditionIfr: t.integer().notNull().default(0),
-	functionPilotInCommand: t.integer().notNull().default(0),
-	functionCoPilot: t.integer().notNull().default(0),
-	functionDual: t.integer().notNull().default(0),
-	functionInstructor: t.integer().notNull().default(0),
-}));
+export const times = sqliteTable("times", {
+	id: text().primaryKey().$defaultFn(v7),
+	totalFlight: integer().notNull().default(0),
+	singlePilotSingleEngine: integer().notNull().default(0),
+	singlePilotMultiEngine: integer().notNull().default(0),
+	multiPilot: integer().notNull().default(0),
+	operationalConditionNight: integer().notNull().default(0),
+	operationalConditionIfr: integer().notNull().default(0),
+	functionPilotInCommand: integer().notNull().default(0),
+	functionCoPilot: integer().notNull().default(0),
+	functionDual: integer().notNull().default(0),
+	functionInstructor: integer().notNull().default(0),
+});
 
 export type Time = typeof times.$inferSelect;
 export type CreateTime = typeof times.$inferInsert;

--- a/db/schema/times.ts
+++ b/db/schema/times.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { v7 } from "uuid";
 
 export const times = sqliteTable("times", {


### PR DESCRIPTION
Replace deprecated `sqliteTable` calls in the `/db/schema` directory with the updated syntax and import missing functions from the drizzle package.

* **db/schema/auth.ts**
  - Replace `sqliteTable` calls with the second argument as an object directly.
  - Import `text` and `integer` from "drizzle-orm/sqlite-core".

* **db/schema/logs.ts**
  - Replace `sqliteTable` calls with the second argument as an object directly.
  - Import `text` and `integer` from "drizzle-orm/sqlite-core".

* **db/schema/pilots.ts**
  - Replace `sqliteTable` calls with the second argument as an object directly.
  - Import `text` from "drizzle-orm".

* **db/schema/places.ts**
  - Replace `sqliteTable` calls with the second argument as an object directly.
  - Import `text` from "drizzle-orm".

* **db/schema/times.ts**
  - Replace `sqliteTable` calls with the second argument as an object directly.
  - Import `text` and `integer` from "drizzle-orm/sqlite-core".

* **db/schema/aircraft.ts**
  - Replace `sqliteTable` calls with the second argument as an object directly.
  - Import `text` from "drizzle-orm".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KacperAdamczyk/logbook/pull/291?shareId=7432ede3-86bb-4dce-af46-47a043c8d25a).